### PR TITLE
[CMakeLists.txt] Add find_package(PythonInterp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Python libraries
 
+find_package(PythonInterp)
 find_package(PythonLibs REQUIRED)
 include_directories(system "${PYTHON_INCLUDE_DIR}")
 add_definitions(


### PR DESCRIPTION
  before `find_package(PythonLibs REQUIRED)`. This enables cmake to detect the
  correct default version of python.